### PR TITLE
fix: Parse initiatorname.iscsi instead of re-rendering file.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -527,8 +527,8 @@ class StorageConnectorCharm(CharmBase):
         for line in lines:
             match = pattern.match(line)
             if match:
-                value = match.group(1).strip()
-                return value
+                initiator_name = match.group(1).strip()
+                return initiator_name
         return None
 
     def _iscsid_configuration(self, tenv: Environment) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -460,7 +460,6 @@ class StorageConnectorCharm(CharmBase):
         charm_config = self.model.config
         initiator_name = None
         hostname = socket.getfqdn()
-        render_file = False
 
         initiators = charm_config.get("initiator-dictionary")
         if initiators:
@@ -483,9 +482,18 @@ class StorageConnectorCharm(CharmBase):
                 hostname,
             )
             render_file = True
-
-        if initiator_name and initiator_name != initiator_name_from_file:
+        elif initiator_name and initiator_name != initiator_name_from_file:
+            # initiator name configuration is provided and isn't the same as
+            # what's already present in the initiatorname.iscsi file.
+            # so render file with provided name
             render_file = True
+        else:
+            # do not render the file again for these cases:
+            # 1. initiator name configuration from initiator-dictionary is same as
+            #    name in initiatorname.iscsi file
+            # 2. no initiator name configuration but name is present in file. use
+            #    the same name.
+            render_file = False
 
         if render_file:
             logging.info("Rendering initiatorname.iscsi")

--- a/src/charm.py
+++ b/src/charm.py
@@ -477,8 +477,8 @@ class StorageConnectorCharm(CharmBase):
             # generate random iqn
             initiator_name = subprocess.getoutput("/sbin/iscsi-iname")
             logging.warning(
-                "Hostname was not found in initiator-dict and config file.\
-                The randomly generated iqn %s will be used for %s",
+                "Hostname was not found in initiator-dict and config file. "
+                + "The randomly generated iqn %s will be used for %s",
                 initiator_name,
                 hostname,
             )
@@ -501,7 +501,7 @@ class StorageConnectorCharm(CharmBase):
 
         Returns:
             "InitiatorName" value in config file if present.
-            False if config file isn't present or "InitiatorName" isn't set.
+            None if config file isn't present or "InitiatorName" isn't set.
         """
         # can't set default param value to instance attribute
         if not iscsi_config_file:

--- a/src/charm.py
+++ b/src/charm.py
@@ -521,14 +521,14 @@ class StorageConnectorCharm(CharmBase):
             logging.warning("%s doesn't exist", iscsi_config_file)
             return None
 
-        initiator_name, value = None, None
+        # "\s*" matches for potential whitespace around "="
+        # The capturing group "(.*)" matches for the iqn assigned to InitiatorName
+        pattern = re.compile(r"^InitiatorName\s*=\s*(.*)$")
         for line in lines:
-            line = line.strip()
-            if line and not line.startswith("#"):
-                initiator_name, value = line.split("=")
-
-        if initiator_name and initiator_name.strip() == "InitiatorName" and value:
-            return value
+            match = pattern.match(line)
+            if match:
+                value = match.group(1).strip()
+                return value
         return None
 
     def _iscsid_configuration(self, tenv: Environment) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -484,7 +484,7 @@ class StorageConnectorCharm(CharmBase):
             )
             render_file = True
 
-        if initiator_name != initiator_name_from_file:
+        if initiator_name and initiator_name != initiator_name_from_file:
             render_file = True
 
         if render_file:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -335,7 +335,10 @@ def test_iscsi_with_initiatorname_not_rendered(mocker, harness, iscsi_config):
 
     assert harness.charm._get_initiator_name_from_file() == "iqn.2020-07.canonical.com:lun1"
     # initiatorname.iscsi not rendered again
-    assert call(expected_initiator_content) not in mock_write_text.mock_calls
+    # assert that there are no Path.write_text calls from _iscsi_initiator.
+    # only write_text calls present are the ones from _multipath_configuration and
+    # _iscsid_configuration
+    assert len(mock_write_text.mock_calls) == 2
     assert isinstance(harness.charm.unit.status, ActiveStatus)
 
     mock_write_text.reset_mock()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,6 +6,7 @@ from unittest.mock import call, mock_open
 
 import charmhelpers.contrib.openstack.deferred_events as deferred_events
 import pytest
+from jinja2 import Environment, FileSystemLoader
 from ops.framework import EventBase
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 
@@ -99,6 +100,16 @@ def test_get_initiator_name_from_file(
         initiatorname_file.write_text(initiator_content)
     initiator_name = harness.charm._get_initiator_name_from_file(initiatorname_file)
     assert initiator_name == expected_initiator_name
+
+
+def test_render_iscsi_initiator(harness, mocker, iscsi_config):
+    """Test method that renders initiator name to /etc/initiatorname.iscsi."""
+    tenv = Environment(loader=FileSystemLoader("templates"))
+    initiator_name = "test-iqn"
+    harness.charm._render_iscsi_initiator(initiator_name, tenv)
+    with open(harness.charm.ISCSI_INITIATOR_NAME) as f:
+        content = f.read()
+    assert f"InitiatorName={initiator_name}" in content
 
 
 def test_on_config_changed_iscsi(harness, mocker, iscsi_config):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -369,6 +369,7 @@ def test_on_config_changed_fc(harness, mocker, fc_config, multipath_topology):
             multipath_topology,
         ],
     )
+    mocker.patch("charm.subprocess.check_call")
     expected_multipath_conf = (
         "###############################################################################\n"
         "# [ WARNING ]\n"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -343,7 +343,11 @@ def test_iscsi_with_initiatorname_not_rendered(mocker, harness, iscsi_config):
     harness.update_config(iscsi_config)
 
     assert call("/sbin/iscsi-iname") not in mock_getoutput.mock_calls
-    assert call(expected_initiator_content) not in mock_write_text.mock_calls
+
+    # assert that there are no Path.write_text calls from _iscsi_initiator.
+    # only write_text calls present are the ones from _multipath_configuration and
+    # _iscsid_configuration
+    assert len(mock_write_text.mock_calls) == 2
     assert isinstance(harness.charm.unit.status, ActiveStatus)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -98,10 +98,7 @@ def test_get_initiator_name_from_file(
     if initiator_content is not None:
         initiatorname_file.write_text(initiator_content)
     initiator_name = harness.charm._get_initiator_name_from_file(initiatorname_file)
-    if expected_initiator_name is None:
-        assert initiator_name is expected_initiator_name
-    else:
-        assert initiator_name == expected_initiator_name
+    assert initiator_name == expected_initiator_name
 
 
 def test_on_config_changed_iscsi(harness, mocker, iscsi_config):
@@ -261,7 +258,7 @@ def test_iscsi_with_initiator_dictionary_hostname(
     harness.update_config(iscsi_config)
 
     if render_expected:
-        mock_render.assert_called_once()
+        assert mock_render.call_args[0][0] == "iqn.2020-07.canonical.com:lun1"
     else:
         mock_render.assert_not_called()
 
@@ -303,11 +300,12 @@ def test_iscsi_without_initiator_dictionary_hostname(
     harness.update_config(iscsi_config)
 
     if render_expected:
-        mock_render.assert_called_once()
+        # only checking the initiator_name arg and not jinja2 environment
+        assert mock_render.call_args[0][0] == "iqn.2020-07.canonical.com:lun1"
     else:
         mock_render.assert_not_called()
 
-    if initiator_content is None or initiator_content == "":
+    if not initiator_content:
         # if file doesn't exist or is empty, random iqn is generated
         assert call("/sbin/iscsi-iname") in mock_getoutput.mock_calls
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -271,8 +271,6 @@ def test_iscsi_with_initiatorname_rendered(mocker, harness, iscsi_config):
 
     assert harness.charm._get_initiator_name_from_file() == "new-iqn"
 
-    # assert that a random iqn isn't generated
-    assert call("/sbin/iscsi-iname") not in mock_getoutput.mock_calls
     # check if file is being rendered with expected content
     mock_write_text.assert_has_calls(
         [
@@ -328,8 +326,6 @@ def test_iscsi_with_initiatorname_not_rendered(mocker, harness, iscsi_config):
     harness.update_config(iscsi_config)
 
     assert harness.charm._get_initiator_name_from_file() == "iqn.2020-07.canonical.com:lun1"
-    # random iqn not generated
-    assert call("/sbin/iscsi-iname") not in mock_getoutput.mock_calls
     # initiatorname.iscsi not rendered again
     assert call(expected_initiator_content) not in mock_write_text.mock_calls
     assert isinstance(harness.charm.unit.status, ActiveStatus)
@@ -341,8 +337,6 @@ def test_iscsi_with_initiatorname_not_rendered(mocker, harness, iscsi_config):
     # reuse the same name and don't render the file again
     iscsi_config["initiator-dictionary"] = "{}"
     harness.update_config(iscsi_config)
-
-    assert call("/sbin/iscsi-iname") not in mock_getoutput.mock_calls
 
     # assert that there are no Path.write_text calls from _iscsi_initiator.
     # only write_text calls present are the ones from _multipath_configuration and


### PR DESCRIPTION
If the initiator-dictionary config option is not provided (or hostname isn't present there), then a random iqn is generated through `/sbin/iscsi-iname` to be used for the initiator name.

But with a config-changed event, this iqn is re-generated even if it has already been generated and set once before in `/etc/iscsi/initiatorname.iscsi`. This causes connectivity issues as mentioned in the linked bug.

This change checks whether the iqn is already present in the `initiatorname.iscsi` file and if so, uses the same instead of re-generating a new one and re-rendering the file (if no configuration is provided via initiator-dictionary). It also prevents re-rendering the file if the initiator name exists and it's the same as the one configured in the initiator-dictionary.

Logic works as follows:

**hostname/ initiator name present in initiator-dictionary**
* If initiator name also present in `initiatorname.iscsi` file:
  * If both names are same, don't render file.
  * If both names are different, render file with value from dictionary
* If initiatorname.iscsi file doesn't exist, render file with name from initiator-dictionary.

**initiator-dictionary absent (or hostname not present there)**
* If initiator name present in initiatorname.iscsi file, don't render file.
* If initiatorname.iscsi file doesn't exist, generate random iqn render file with it.

A subprocess call has also been patched in one of the unit tests which would have otherwise run directly on the host system.

Fixes #3 