### PR TITLE
Support juju 3.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,7 +29,7 @@ jobs:
       python-version: ${{ matrix.python-version }}
 
   func:
-    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
+    uses: canonical/bootstack-actions/.github/workflows/func.yaml@v2
     needs: lint-unit
     strategy:
       fail-fast: false
@@ -43,12 +43,3 @@ jobs:
       provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      runs-on: "['self-hosted', 'runner-storage-connector']"
-      action-operator: false
-      external-controller: true
-      juju-controller: soleng-ci-ctrl-34
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAoK"
-    secrets:
-      juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
-      juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}
-      openstack-auth-env: ${{ secrets.OPENSTACK_AUTH_ENV }}

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,6 +14,10 @@ on:
       - '**.md'
       - '**.rst'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-unit:
     uses: canonical/bootstack-actions/.github/workflows/lint-unit.yaml@v2
@@ -23,26 +27,27 @@ jobs:
         python-version: ["3.8", "3.10"]
     with:
       python-version: ${{ matrix.python-version }}
-      tox-version: "<4"
 
   func:
     uses: canonical/bootstack-actions/.github/workflows/func.yaml@v3
     needs: lint-unit
     strategy:
       fail-fast: false
+      matrix:
+        command: ["TEST_JUJU3=1 make functional"]  # TEST_JUJU3 needed due https://github.com/openstack-charmers/zaza/blob/b22c2eed4c322f1dfc14ffb2d31e0dd18c911a40/setup.py#L47 to support Juju3+
+        juju-channel: ["3.4/stable"]
     with:
-      command: "make functional"
-      juju-channel: "3.1/stable"
+      command: ${{ matrix.command }}
+      juju-channel: ${{ matrix.juju-channel }}
       nested-containers: false
-      provider: "microstack"
+      provider: "lxd"
       python-version: "3.10"
       timeout-minutes: 120
-      tox-version: "<4"
       runs-on: "['self-hosted', 'runner-storage-connector']"
       action-operator: false
       external-controller: true
-      juju-controller: soleng-ci-ctrl
-      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAo="
+      juju-controller: soleng-ci-ctrl-34
+      zaza-yaml: "LS0tCm1vZGVsX3NldHRpbmdzOgogIGltYWdlLXN0cmVhbTogcmVsZWFzZWQKcmVnaW9uOiBwcm9kc3RhY2s2CmNsb3VkOiBidWlsZGVyLWNsb3VkCmNyZWRlbnRpYWw6IGJ1aWxkZXItY2xvdWQtY3JlZAoK"
     secrets:
       juju-controllers-yaml: ${{ secrets.JUJU_CONTROLLERS_YAML }}
       juju-accounts-yaml: ${{ secrets.JUJU_ACCOUNTS_YAML }}

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,6 @@ submodules-update:
 	@git submodule update --init --recursive --remote --merge
 
 clean:
-	@echo "Cleaning files"
-	@git clean -ffXd -e '!.idea' -e '!.vscode'
 	@echo "Cleaning existing build"
 	@rm -rf ${PROJECTPATH}/${CHARM_NAME}*.charm
 	@echo "Cleaning charmcraft"

--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -1,2 +1,2 @@
 git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack
-git+https://github.com/openstack-charmers/zaza.git@libjuju-3.1#egg=zaza
+git+https://github.com/openstack-charmers/zaza.git@master#egg=zaza

--- a/tests/functional/tests/bundles/base.yaml
+++ b/tests/functional/tests/bundles/base.yaml
@@ -1,0 +1,13 @@
+applications:
+  storage-connector:
+    charm: ch:storage-connector
+  ubuntu-target:
+    charm: ch:ubuntu
+    num_units: 1
+  ubuntu:
+    charm: ch:ubuntu
+    num_units: 1
+    constraints: root-disk=8G cores=2 virt-type=virtual-machine
+relations:
+  - - 'ubuntu:juju-info'
+    - 'storage-connector:host'

--- a/tests/functional/tests/bundles/focal-fc.yaml
+++ b/tests/functional/tests/bundles/focal-fc.yaml
@@ -2,6 +2,7 @@ local_overlay_enabled: True
 series: focal
 applications:
   storage-connector:
+    charm: ch:storage-connector
     options:
       storage-type: 'fc'
       fc-lun-alias: 'data1'

--- a/tests/functional/tests/bundles/focal.yaml
+++ b/tests/functional/tests/bundles/focal.yaml
@@ -1,12 +1,1 @@
-local_overlay_enabled: True
-series: focal
-applications:
-  ubuntu-target:
-    charm: ch:ubuntu
-    num_units: 1
-  ubuntu:
-    charm: ch:ubuntu
-    num_units: 1
-relations:
-  - - 'ubuntu:juju-info'
-    - 'storage-connector:host'
+base.yaml

--- a/tests/functional/tests/bundles/jammy.yaml
+++ b/tests/functional/tests/bundles/jammy.yaml
@@ -1,12 +1,1 @@
-local_overlay_enabled: True
-series: jammy
-applications:
-  ubuntu-target:
-    charm: ch:ubuntu
-    num_units: 1
-  ubuntu:
-    charm: ch:ubuntu
-    num_units: 1
-relations:
-  - - 'ubuntu:juju-info'
-    - 'storage-connector:host'
+base.yaml

--- a/tests/functional/tests/bundles/overlays/focal.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/focal.yaml.j2
@@ -1,0 +1,1 @@
+series: focal

--- a/tests/functional/tests/bundles/overlays/jammy.yaml.j2
+++ b/tests/functional/tests/bundles/overlays/jammy.yaml.j2
@@ -1,0 +1,1 @@
+series: jammy

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
   SNAP_HTTP_PROXY
   SNAP_HTTPS_PROXY
   OS_*
+  TEST_*
 
 [testenv:dev-environment]
 envdir = {toxinidir}/.venv


### PR DESCRIPTION
Add support for Juju 3.4, small clean up in Makefile and func test bundles (using base.yaml) and mayor change is to switch to run these test on LXD, so official GitHub runner can be used instead of self-hosted. 

Add workflow concurrency to avoid running multiple workflows on a single PR. Like this if new commit arrived the previous run will be canceled by new run.