### PR TITLE
style: lint fix

### DIFF
--- a/files/check_iscsi_metric.py
+++ b/files/check_iscsi_metric.py
@@ -6,6 +6,7 @@
 #          Mert Kırpıcı       <mert.kirpici@canonical.com>
 #
 """NRPE check script for iscsi metrics."""
+
 import re
 import subprocess
 import sys

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,7 +2,6 @@
 
 """Iscsi Connector Charm."""
 
-
 import json
 import logging
 import os

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,10 @@ commands =
     isort --check --diff --color .
     flake8
 deps =
-    black
+    # Pin black < 25 so the Python 3.8 and 3.10 lint jobs install the same
+    # major. black >= 25 drops 3.8 support and formats multiline strings
+    # differently, so the two jobs would otherwise disagree.
+    black<25
     colorama
     flake8
     flake8-colors
@@ -44,7 +47,7 @@ commands =
     black .
     isort .
 deps =
-    black
+    black<25
     isort
 
 [testenv:unit]


### PR DESCRIPTION
The lint matrix runs on Python 3.8 and 3.10 with an unpinned black. black>=25 (installed on 3.10) drops 3.8 support and hugs multiline strings in call parens, while black 24.x (installed on 3.8) expands them, so the two jobs disagreed and Lint (3.8) failed.

Pin black<25 in the lint/reformat envs so both jobs use the same major, and reformat the affected files with black 24.x.